### PR TITLE
Delete deprecated nodes from launch file

### DIFF
--- a/launch/display.launch
+++ b/launch/display.launch
@@ -7,11 +7,11 @@
 
     <!-- load robot -->
     <param name="robot_description" command="$(find xacro)/xacro.py '$(find hsr_description)/robots/$(arg robot).urdf.xacro' use_obj_for_visual:=$(arg use_obj)" />
-    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="joint_state_publisher" pkg="joint_state_publisher_gui" type="joint_state_publisher_gui" if="$(arg gui)"/>
+    <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" unless="$(arg gui)"/>
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <!-- load displays -->
-    <param name="use_gui" value="$(arg gui)"/>
     <node name="rviz" pkg="rviz" type="rviz" args="-d $(find hsr_description)/launch/display.rviz"/>
 
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -26,6 +26,7 @@
 
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>joint_state_publisher_gui</exec_depend>
   <exec_depend>hsr_meshes</exec_depend>
   <exec_depend>rviz</exec_depend>
 </package>


### PR DESCRIPTION
I deleted deprecated packages (state_publisher and joint_state_publisher with use_gui param) from launch file. And I also fixed package.xml.